### PR TITLE
Disable push workflow trigger for pull requests

### DIFF
--- a/.github/workflows/build_push_ds.yaml
+++ b/.github/workflows/build_push_ds.yaml
@@ -14,9 +14,6 @@ on:
 
     paths:
       - 'versions.yml'
-  pull_request:
-    paths:
-      - 'versions.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Remove pull_request trigger from build_push_ds workflow to prevent expensive build/push operations during PR reviews. The workflow will still run when PRs are merged to main or Datastream_Workflows branches.

[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

- This resolves https://github.com/CIROH-UA/datastreamcli/issues/31

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
