### PR TITLE
Add ARM64 build and test workflow

### DIFF
--- a/.github/workflows/build_test_ds_arm.yaml
+++ b/.github/workflows/build_test_ds_arm.yaml
@@ -34,20 +34,19 @@ jobs:
       - name: Check for deps Dockerfile changes
         id: changes
         run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "deps=true" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" == "pull_request" ]; then
-            if git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} | grep -q "docker/Dockerfile.datastream-deps"; then
-              echo "deps=true" >> $GITHUB_OUTPUT
-            else
-              echo "deps=false" >> $GITHUB_OUTPUT
-            fi
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            DIFF=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})
+          elif [ "${{ github.event_name }}" == "push" ]; then
+            DIFF=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
           else
-            if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -q "docker/Dockerfile.datastream-deps"; then
-              echo "deps=true" >> $GITHUB_OUTPUT
-            else
-              echo "deps=false" >> $GITHUB_OUTPUT
-            fi
+            # workflow_dispatch: compare against main
+            DIFF=$(git diff --name-only origin/main...HEAD)
+          fi
+
+          if echo "$DIFF" | grep -q "docker/Dockerfile.datastream-deps"; then
+            echo "deps=true" >> $GITHUB_OUTPUT
+          else
+            echo "deps=false" >> $GITHUB_OUTPUT
           fi
 
   build-arm64:


### PR DESCRIPTION
## Summary
Adds a new GitHub Actions workflow for building and testing datastreamcli Docker containers on ARM64 architecture using self-hosted runners.

## Changes
- New workflow `build_test_ds_arm.yaml` for ARM64 builds
- Builds datastream image using `latest-arm64` tag
- Parallel test execution with matrix strategy (10 test suites)
- Automatic cleanup of Docker images and artifacts after tests

## Workflow Jobs
1. **build-arm64**: Pulls deps, builds datastream image, uploads artifact
2. **test-arm64**: Runs 10 parallel test suites against built image
3. **cleanup-artifacts**: Cleans up Docker images and deletes artifacts

## Test Suites
- Validation tests (geopackage, realization, BMI config, forcings, t-route)
- BMI Config Generation tests
- Configuration tests

## Triggers
- Push to `main` or `dev` branches (when docker/src/tests change)
- Pull requests (when docker/src/tests change)
- Manual workflow dispatch