### PR TITLE
fix: correct double dollar sign typo in datastream script

### DIFF
--- a/scripts/datastream
+++ b/scripts/datastream
@@ -573,7 +573,7 @@ else
         FP_HASH=$(docker inspect --format='{{json .Id}}' $(docker image ls $DOCKER_TAG --format "{{.ID}}") | tr -d '"')
         # mv $DATASTREAM_RESOURCES/profile_fp.txt $DATASTREAM_META 
         log_time "FORCINGPROCESSOR_END"
-        if [ ! -e $$DATASTREAM_RESOURCES_NGENFORCINGS ]; then
+        if [ ! -e $DATASTREAM_RESOURCES_NGENFORCINGS ]; then
             mkdir -p $DATASTREAM_RESOURCES_NGENFORCINGS
         fi
         FORCINGS_BASE=$(basename $(find "$NGENRUN_FORCINGS" -type f -name "*forcing*"))


### PR DESCRIPTION
## Summary

Fixes a typo on line 576 where `$$` was used instead of `$` for the variable `DATASTREAM_RESOURCES_NGENFORCINGS`.

## The Bug

```bash
# Before (incorrect)
if [ ! -e $$DATASTREAM_RESOURCES_NGENFORCINGS ]; then

# After (correct)  
if [ ! -e $DATASTREAM_RESOURCES_NGENFORCINGS ]; then
```

## Why It Didn't Break

In bash, `$$` returns the current process ID (e.g., `12345`), so the condition was checking if a path like `12345DATASTREAM_RESOURCES_NGENFORCINGS` exists - which always fails.

However, the bug was harmless because:
- The condition was always `true` (path never exists)
- `mkdir -p` is idempotent (safe to run even if directory exists)
- The correct `$` variable was used inside the block

## Why Fix It

- Code clarity and correctness
- Matches the intended behavior
- Prevents confusion during code review

## Testing

- Verified the script still runs correctly after the fix