### PR TITLE
Fix ARM workflow pre-cleanup to handle hidden directories

### DIFF
--- a/.github/workflows/build_test_ds_arm.yaml
+++ b/.github/workflows/build_test_ds_arm.yaml
@@ -36,11 +36,11 @@ jobs:
           aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws configure set region us-east-1
 
-      # - name: Build datastream-deps
-      #   run: |
-      #     cd docker
-      #     ARCH=aarch64 TAG=latest-arm64 \
-      #       docker compose -f docker-compose.yml build datastream-deps
+      - name: Build datastream-deps
+        run: |
+          cd docker
+          ARCH=aarch64 TAG=latest-arm64 \
+            docker compose -f docker-compose.yml build datastream-deps
 
       - name: Build datastream
         run: |


### PR DESCRIPTION
## Problem
ARM workflow was failing on checkout with permission errors like:
```
Error: File was unable to be removed Error: EACCES: permission denied, 
unlink '.pytest_cache/.gitignore'
```

This happens because Docker containers run as root and create files that the GitHub runner user can't delete.

This was blocking PR #40 from passing CI: https://github.com/CIROH-UA/datastreamcli/pull/40

## Fix
**Better pre-cleanup** - Use `sudo rm -rf` to nuke the entire workspace before checkout (the old `.*` pattern didn't work for hidden directories)

 **Disable checkout's built-in clean** - Add `clean: false` so checkout doesn't try to delete files it can't remove

**Prevent future issues** - Run Docker tests with `--user $(id -u):$(id -g)` so pytest cache files are created with the runner's ownership, not root
