### PR TITLE
Add hfsubset down note

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,17 @@ This example will execute a 24 hour NextGen simulation over the Palisade, Colora
 
 First, obtain a hydrofabric file for the gage you wish to model. There are several tooling options to use to obtain a geopackage. One of which, [hfsubset](https://github.com/lynker-spatial/hfsubsetCLI), is maintained by Lynker and is integrated in DataStreamCLI. 
 
-For Palisade, Colorado:
-```
-hfsubset -w medium_range \
-          -s nextgen \
-          -v 2.1.1 \
-          -l divides,flowlines,network,nexus,forcing-weights,flowpath-attributes,model-attributes \
-          -o palisade.gpkg \
-          -t hl "Gages-09106150"
-```
+❗`hfsubset` is currently down. To obtain a test geopackage, use this [geopackage](https://ciroh-community-ngen-datastream.s3.amazonaws.com/resources/v2.1_hydrofabric/geopackages/test_data/palisade.gpkg) of the upstream watershed of Palisade, Colorado. 
+
+> For Palisade, Colorado:
+>```
+> hfsubset -w medium_range \
+>          -s nextgen \
+>          -v 2.1.1 \
+>          -l divides,flowlines,network,nexus,forcing-weights,flowpath-attributes,model-attributes \
+>          -o palisade.gpkg \
+>          -t hl "Gages-09106150"
+>```
 
 Then feed the hydrofabric file to DataStreamCLI along with a few cli args to define the time domain and NextGen configuration
 ```


### PR DESCRIPTION
Updated instructions for obtaining a geopackage for Palisade, Colorado, noting that hfsubset is currently down and providing a link to a test geopackage.

Resolves https://github.com/CIROH-UA/datastreamcli/issues/59

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
