### PR TITLE
Replace cat sm_ARN.txt with terraform output for state machine ARN

### DIFF
--- a/.github/workflows/build_push_ds.yaml
+++ b/.github/workflows/build_push_ds.yaml
@@ -286,7 +286,7 @@ jobs:
       - name: clone ngen
         if: steps.prep_config.outputs.skip_arm_build != 'true'
         run: |
-          git clone --single-branch --branch main --depth 1 https://github.com/CIROH-UA/ngen-datastream.git
+          git clone --single-branch --branch v2.2.0 --depth 1 https://github.com/CIROH-UA/ngen-datastream.git
 
       - name: Build AWS Infra
         if: steps.prep_config.outputs.skip_arm_build != 'true'

--- a/.github/workflows/integration_ds_fp_arm.yaml
+++ b/.github/workflows/integration_ds_fp_arm.yaml
@@ -94,7 +94,7 @@ jobs:
 
       - name: clone ngen
         run: |
-          git clone --single-branch --branch main --depth 1 https://github.com/CIROH-UA/ngen-datastream.git
+          git clone --single-branch --branch v2.2.0 --depth 1 https://github.com/CIROH-UA/ngen-datastream.git
 
       - name: Build AWS Infra
         working-directory: ngen-datastream/infra/aws/terraform/modules/orchestration


### PR DESCRIPTION
## Summary
- The `ngen-datastream` repo removed the `local_file` resource that generated `sm_ARN.txt` ([CIROH-UA/ngen-datastream#339](https://github.com/CIROH-UA/ngen-datastream/pull/339))
- Replaces `cat ./sm_ARN.txt` with `terraform output -raw datastream_arn` in both `build_push_ds.yaml` and `integration_ds_fp_arm.yaml`
- Adds `terraform_wrapper: false` to `hashicorp/setup-terraform` so command substitution captures the raw ARN value correctly
