### PR TITLE
Remove buildx from x86 build job, fix trivy action tag

### DIFF
--- a/.github/workflows/build_push_ds.yaml
+++ b/.github/workflows/build_push_ds.yaml
@@ -124,12 +124,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
     - name: Configure AWS
       run: |
         aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -151,7 +145,7 @@ jobs:
 
     - name: Run Trivy vulnerability scan - deps (JSON for artifacts)
       if:  needs.detect-changes.outputs.build_deps == 'true'
-      uses: aquasecurity/trivy-action@0.28.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         image-ref: 'awiciroh/datastream-deps:latest-x86'
         format: 'json'
@@ -161,7 +155,7 @@ jobs:
 
     - name: Run Trivy vulnerability scan - ds (JSON for artifacts)
       if:  needs.detect-changes.outputs.build_ds == 'true'
-      uses: aquasecurity/trivy-action@0.28.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         image-ref: 'awiciroh/datastream:latest-x86'
         format: 'json'


### PR DESCRIPTION
- Remove setup-buildx-action and setup-qemu-action from x86 job. The docker-container driver runs builds in isolation and can't see locally built images, causing the datastream build to pull stale deps from Docker Hub.
- Fix trivy-action tag from 0.28.0 (doesn't exist) to v0.35.0 pinned by commit SHA.