### PR TITLE
Build deps when versions.yml changes in test workflows

### DIFF
--- a/.github/workflows/test_datastream_ngiab.yaml
+++ b/.github/workflows/test_datastream_ngiab.yaml
@@ -8,21 +8,23 @@ on:
     paths:
       - .github/workflow/test_datastream_options.yaml
       - 'docker/**'
-      - '!docker/README.md'      
-      - 'scripts/datastream'  
-      - 'src/datastreamcli/**'  
-      - '!src/datastreamcli/README.md'      
+      - '!docker/README.md'
+      - 'scripts/datastream'
+      - 'src/datastreamcli/**'
+      - '!src/datastreamcli/README.md'
+      - 'versions.yml'
 
   pull_request:
     branches:
-      - main  
+      - main
     paths:
       - .github/workflow/test_datastream_options.yaml
       - 'docker/**'
-      - '!docker/README.md'      
-      - 'scripts/datastream'  
-      - 'src/datastreamcli/**'  
-      - '!src/datastreamcli/README.md'            
+      - '!docker/README.md'
+      - 'scripts/datastream'
+      - 'src/datastreamcli/**'
+      - '!src/datastreamcli/README.md'
+      - 'versions.yml'            
 
 permissions:
   contents: read      
@@ -47,17 +49,30 @@ jobs:
     - name: Build or pull datastream-deps
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          DIFF=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
         elif [ "${{ github.event_name }}" == "push" ]; then
-          DIFF=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+          BASE=${{ github.event.before }}
+          HEAD=${{ github.sha }}
         else
-          DIFF=$(git diff --name-only origin/main...HEAD)
+          BASE=origin/main
+          HEAD=HEAD
         fi
+        DIFF=$(git diff --name-only $BASE...$HEAD)
+        BUILD_DEPS=false
         if echo "$DIFF" | grep -q "docker/Dockerfile.datastream-deps"; then
-          echo "Deps Dockerfile changed, building..."
+          BUILD_DEPS=true
+        fi
+        if echo "$DIFF" | grep -q "versions.yml"; then
+          if git diff -U0 $BASE...$HEAD -- versions.yml | grep -q "datastream-deps"; then
+            BUILD_DEPS=true
+          fi
+        fi
+        if [ "$BUILD_DEPS" = true ]; then
+          echo "Deps changed, building..."
           docker compose -f docker/docker-compose.yml build datastream-deps
         else
-          echo "Deps Dockerfile unchanged, pulling from Docker Hub..."
+          echo "Deps unchanged, pulling from Docker Hub..."
           docker pull awiciroh/datastream-deps:latest
         fi
 

--- a/.github/workflows/test_datastream_options.yaml
+++ b/.github/workflows/test_datastream_options.yaml
@@ -8,12 +8,14 @@ on:
       - '.github/workflows/test_datastream_options.yaml'
       - 'scripts/datastream'
       - 'versions.yml'
+      - 'docker/Dockerfile.datastream-deps'
   pull_request:
     branches: [main]
     paths:
       - '.github/workflows/test_datastream_options.yaml'
       - 'scripts/datastream'
       - 'versions.yml'
+      - 'docker/Dockerfile.datastream-deps'
 
 permissions:
   contents: read
@@ -35,17 +37,30 @@ jobs:
       - name: Build or pull datastream-deps
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            DIFF=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})
+            BASE=${{ github.event.pull_request.base.sha }}
+            HEAD=${{ github.event.pull_request.head.sha }}
           elif [ "${{ github.event_name }}" == "push" ]; then
-            DIFF=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+            BASE=${{ github.event.before }}
+            HEAD=${{ github.sha }}
           else
-            DIFF=$(git diff --name-only origin/main...HEAD)
+            BASE=origin/main
+            HEAD=HEAD
           fi
+          DIFF=$(git diff --name-only $BASE...$HEAD)
+          BUILD_DEPS=false
           if echo "$DIFF" | grep -q "docker/Dockerfile.datastream-deps"; then
-            echo "Deps Dockerfile changed, building..."
+            BUILD_DEPS=true
+          fi
+          if echo "$DIFF" | grep -q "versions.yml"; then
+            if git diff -U0 $BASE...$HEAD -- versions.yml | grep -q "datastream-deps"; then
+              BUILD_DEPS=true
+            fi
+          fi
+          if [ "$BUILD_DEPS" = true ]; then
+            echo "Deps changed, building..."
             docker compose -f docker/docker-compose.yml build datastream-deps
           else
-            echo "Deps Dockerfile unchanged, pulling from Docker Hub..."
+            echo "Deps unchanged, pulling from Docker Hub..."
             docker pull awiciroh/datastream-deps:latest
           fi
 

--- a/.github/workflows/test_datastream_options_forcings_sources.yaml
+++ b/.github/workflows/test_datastream_options_forcings_sources.yaml
@@ -8,12 +8,14 @@ on:
       - '.github/workflows/test_datastream_options_forcings_sources.yaml'
       - 'scripts/datastream'
       - 'versions.yml'
+      - 'docker/Dockerfile.datastream-deps'
   pull_request:
     branches: [main]
     paths:
       - '.github/workflows/test_datastream_options_forcings_sources.yaml'
       - 'scripts/datastream'
       - 'versions.yml'
+      - 'docker/Dockerfile.datastream-deps'
 
 permissions:
   contents: read
@@ -35,17 +37,30 @@ jobs:
       - name: Build or pull datastream-deps
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            DIFF=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})
+            BASE=${{ github.event.pull_request.base.sha }}
+            HEAD=${{ github.event.pull_request.head.sha }}
           elif [ "${{ github.event_name }}" == "push" ]; then
-            DIFF=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+            BASE=${{ github.event.before }}
+            HEAD=${{ github.sha }}
           else
-            DIFF=$(git diff --name-only origin/main...HEAD)
+            BASE=origin/main
+            HEAD=HEAD
           fi
+          DIFF=$(git diff --name-only $BASE...$HEAD)
+          BUILD_DEPS=false
           if echo "$DIFF" | grep -q "docker/Dockerfile.datastream-deps"; then
-            echo "Deps Dockerfile changed, building..."
+            BUILD_DEPS=true
+          fi
+          if echo "$DIFF" | grep -q "versions.yml"; then
+            if git diff -U0 $BASE...$HEAD -- versions.yml | grep -q "datastream-deps"; then
+              BUILD_DEPS=true
+            fi
+          fi
+          if [ "$BUILD_DEPS" = true ]; then
+            echo "Deps changed, building..."
             docker compose -f docker/docker-compose.yml build datastream-deps
           else
-            echo "Deps Dockerfile unchanged, pulling from Docker Hub..."
+            echo "Deps unchanged, pulling from Docker Hub..."
             docker pull awiciroh/datastream-deps:latest
           fi
 

--- a/.github/workflows/test_teehr_integration.yaml
+++ b/.github/workflows/test_teehr_integration.yaml
@@ -6,13 +6,17 @@ on:
     branches:
       - main
     paths:
-      - 'scripts/datastream'    
-      
+      - 'scripts/datastream'
+      - 'versions.yml'
+      - 'docker/Dockerfile.datastream-deps'
+
   push:
     branches:
       - main
     paths:
-      - 'scripts/datastream'      
+      - 'scripts/datastream'
+      - 'versions.yml'
+      - 'docker/Dockerfile.datastream-deps'      
 
 permissions:
   contents: read  
@@ -39,17 +43,30 @@ jobs:
     - name: Build or pull datastream-deps
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          DIFF=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
         elif [ "${{ github.event_name }}" == "push" ]; then
-          DIFF=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+          BASE=${{ github.event.before }}
+          HEAD=${{ github.sha }}
         else
-          DIFF=$(git diff --name-only origin/main...HEAD)
+          BASE=origin/main
+          HEAD=HEAD
         fi
+        DIFF=$(git diff --name-only $BASE...$HEAD)
+        BUILD_DEPS=false
         if echo "$DIFF" | grep -q "docker/Dockerfile.datastream-deps"; then
-          echo "Deps Dockerfile changed, building..."
+          BUILD_DEPS=true
+        fi
+        if echo "$DIFF" | grep -q "versions.yml"; then
+          if git diff -U0 $BASE...$HEAD -- versions.yml | grep -q "datastream-deps"; then
+            BUILD_DEPS=true
+          fi
+        fi
+        if [ "$BUILD_DEPS" = true ]; then
+          echo "Deps changed, building..."
           docker compose -f docker/docker-compose.yml build datastream-deps
         else
-          echo "Deps Dockerfile unchanged, pulling from Docker Hub..."
+          echo "Deps unchanged, pulling from Docker Hub..."
           docker pull awiciroh/datastream-deps:latest
         fi
 


### PR DESCRIPTION
Test workflows now build deps locally instead of pulling from Docker Hub when versions.yml changes.
Also adds versions.yml to paths trigger for ngiab and teehr workflows.