### PR TITLE
Security: migrate workflows from static AWS keys to OIDC

### DIFF
--- a/.github/executions/ds_push_execution_arm.json
+++ b/.github/executions/ds_push_execution_arm.json
@@ -36,7 +36,11 @@
         "Tags": [
             {
                 "Key"   : "Name",
-                "Value" : "arm_docker_buildNtester"
+                "Value" : "ci_ds_build_push_arm"
+            },
+            {
+                "Key"   : "Project",
+                "Value" : "ci_ds_build_push_arm"
             }
         ]
     }

--- a/.github/executions/fp_ds_test_execution_arm.json
+++ b/.github/executions/fp_ds_test_execution_arm.json
@@ -30,7 +30,11 @@
         "Tags": [
             {
                 "Key"   : "Name",
-                "Value" : "arm_docker_buildNtester"
+                "Value" : "ci_ds_integration_test_arm"
+            },
+            {
+                "Key"   : "Project",
+                "Value" : "ci_ds_integration_test_arm"
             }
         ]
     }

--- a/.github/workflows/build_push_ds.yaml
+++ b/.github/workflows/build_push_ds.yaml
@@ -128,7 +128,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
         aws-region: us-east-1
 
     - name: Build docker containers
@@ -212,7 +212,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       # Dynamically configures the test execution JSON by setting the branch name and conditionally removing Docker build commands for containers whose Dockerfiles haven't changed (optimization only applies to push events, not manual triggers)

--- a/.github/workflows/build_push_ds.yaml
+++ b/.github/workflows/build_push_ds.yaml
@@ -128,7 +128,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
         aws-region: us-east-1
 
     - name: Build docker containers
@@ -212,7 +212,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       # Dynamically configures the test execution JSON by setting the branch name and conditionally removing Docker build commands for containers whose Dockerfiles haven't changed (optimization only applies to push events, not manual triggers)

--- a/.github/workflows/build_push_ds.yaml
+++ b/.github/workflows/build_push_ds.yaml
@@ -26,6 +26,7 @@ on:
       - 'versions.yml'
 
 permissions:
+  id-token: write
   contents: read
   security-events: write
 
@@ -124,12 +125,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Configure AWS
-      run: |
-        aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws configure set region us-east-1
-         
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+        aws-region: us-east-1
+
     - name: Build docker containers
       run: |
           if [ "${{ needs.detect-changes.outputs.build_deps }}" == "true" ]; then
@@ -208,11 +209,11 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
 
       # Dynamically configures the test execution JSON by setting the branch name and conditionally removing Docker build commands for containers whose Dockerfiles haven't changed (optimization only applies to push events, not manual triggers)
       - name: Prepare execution config

--- a/.github/workflows/build_test_ds_arm.yaml
+++ b/.github/workflows/build_test_ds_arm.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Build datastream-deps (only if Dockerfile changed)
@@ -201,7 +201,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Run ${{ matrix.test-suite.name }}
@@ -211,8 +211,8 @@ jobs:
             -v $(pwd):/datastream \
             -w /datastream \
             -e AWS_REGION=us-east-1 \
-            -e AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }} \
-            -e AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }} \
-            -e AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }} \
+            -e "AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}" \
+            -e "AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}" \
+            -e "AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}" \
             awiciroh/${{ matrix.test-suite.image }}:latest-arm64 \
             ${{ matrix.test-suite.command }}

--- a/.github/workflows/build_test_ds_arm.yaml
+++ b/.github/workflows/build_test_ds_arm.yaml
@@ -17,6 +17,7 @@ on:
       - 'tests/**'
       - '!src/datastreamcli/README.md'
 permissions:
+  id-token: write
   contents: read
   security-events: write
 
@@ -63,11 +64,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
 
       - name: Build datastream-deps (only if Dockerfile changed)
         if: needs.detect-changes.outputs.deps-changed == 'true'
@@ -197,6 +198,12 @@ jobs:
             fi
           done
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
+
       - name: Run ${{ matrix.test-suite.name }}
         run: |
           docker run --rm \
@@ -204,7 +211,8 @@ jobs:
             -v $(pwd):/datastream \
             -w /datastream \
             -e AWS_REGION=us-east-1 \
-            -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
-            -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+            -e AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }} \
+            -e AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }} \
+            -e AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }} \
             awiciroh/${{ matrix.test-suite.image }}:latest-arm64 \
             ${{ matrix.test-suite.command }}

--- a/.github/workflows/build_test_ds_arm.yaml
+++ b/.github/workflows/build_test_ds_arm.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Build datastream-deps (only if Dockerfile changed)
@@ -201,7 +201,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Run ${{ matrix.test-suite.name }}

--- a/.github/workflows/build_test_ds_x86.yaml
+++ b/.github/workflows/build_test_ds_x86.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Build datastream-deps (only if Dockerfile changed)
@@ -197,7 +197,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Run ${{ matrix.test-suite.name }}

--- a/.github/workflows/build_test_ds_x86.yaml
+++ b/.github/workflows/build_test_ds_x86.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Build datastream-deps (only if Dockerfile changed)
@@ -197,7 +197,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Run ${{ matrix.test-suite.name }}
@@ -206,9 +206,9 @@ jobs:
             -v ${{ github.workspace }}:/datastreamcli \
             -w /datastreamcli \
             -e AWS_REGION=us-east-1 \
-            -e AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }} \
-            -e AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }} \
-            -e AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }} \
+            -e "AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}" \
+            -e "AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}" \
+            -e "AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}" \
             awiciroh/${{ matrix.test-suite.image }}:latest-x86 \
             ${{ matrix.test-suite.command }}
           

--- a/.github/workflows/build_test_ds_x86.yaml
+++ b/.github/workflows/build_test_ds_x86.yaml
@@ -18,6 +18,7 @@ on:
       - '!src/datastreamcli/README.md'
 
 permissions:
+  id-token: write
   contents: read
   security-events: write
 
@@ -62,11 +63,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
 
       - name: Build datastream-deps (only if Dockerfile changed)
         if: needs.detect-changes.outputs.deps-changed == 'true'
@@ -193,14 +194,21 @@ jobs:
             fi
           done
           
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
+
       - name: Run ${{ matrix.test-suite.name }}
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/datastreamcli \
             -w /datastreamcli \
             -e AWS_REGION=us-east-1 \
-            -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
-            -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+            -e AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }} \
+            -e AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }} \
+            -e AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }} \
             awiciroh/${{ matrix.test-suite.image }}:latest-x86 \
             ${{ matrix.test-suite.command }}
           

--- a/.github/workflows/integration_ds_fp_arm.yaml
+++ b/.github/workflows/integration_ds_fp_arm.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       # Dynamically configures the test execution JSON by setting the branch name and conditionally removing Docker build commands for containers whose Dockerfiles haven't changed (optimization only applies to push events, not manual triggers)

--- a/.github/workflows/integration_ds_fp_arm.yaml
+++ b/.github/workflows/integration_ds_fp_arm.yaml
@@ -35,8 +35,9 @@ on:
       - '!src/datastreamcli/README.md'
   
 permissions:
+  id-token: write
   contents: read
-  security-events: write 
+  security-events: write
 
 jobs:    
   build-test-docker-arm:
@@ -50,11 +51,11 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1        
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
 
       # Dynamically configures the test execution JSON by setting the branch name and conditionally removing Docker build commands for containers whose Dockerfiles haven't changed (optimization only applies to push events, not manual triggers)
       - name: Prepare execution config

--- a/.github/workflows/integration_ds_fp_arm.yaml
+++ b/.github/workflows/integration_ds_fp_arm.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       # Dynamically configures the test execution JSON by setting the branch name and conditionally removing Docker build commands for containers whose Dockerfiles haven't changed (optimization only applies to push events, not manual triggers)

--- a/.github/workflows/integration_ds_fp_x86.yaml
+++ b/.github/workflows/integration_ds_fp_x86.yaml
@@ -50,7 +50,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
         aws-region: us-east-1
 
     - name: Build docker containers

--- a/.github/workflows/integration_ds_fp_x86.yaml
+++ b/.github/workflows/integration_ds_fp_x86.yaml
@@ -50,7 +50,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
         aws-region: us-east-1
 
     - name: Build docker containers

--- a/.github/workflows/integration_ds_fp_x86.yaml
+++ b/.github/workflows/integration_ds_fp_x86.yaml
@@ -28,8 +28,9 @@ on:
       - '!src/datastreamcli/README.md'
   
 permissions:
+  id-token: write
   contents: read
-  security-events: write 
+  security-events: write
 
 jobs:
   build-test-docker-x86:
@@ -46,12 +47,12 @@ jobs:
         username: ${{secrets.DOCKERHUB_USERNAME}}
         password: ${{secrets.DOCKERHUB_TOKEN}}        
 
-    - name: Configure AWS
-      run: |
-        aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws configure set region us-east-1
-        
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+        aws-region: us-east-1
+
     - name: Build docker containers
       run : |
         if [ -z "${{ inputs.fp_tag }}" ]; then

--- a/.github/workflows/test_datastream_ngiab.yaml
+++ b/.github/workflows/test_datastream_ngiab.yaml
@@ -42,7 +42,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
         aws-region: us-east-1
 
     - name: Build or pull datastream-deps

--- a/.github/workflows/test_datastream_ngiab.yaml
+++ b/.github/workflows/test_datastream_ngiab.yaml
@@ -27,7 +27,8 @@ on:
       - 'versions.yml'            
 
 permissions:
-  contents: read      
+  id-token: write
+  contents: read
 
 jobs:
   test-ngiab-integration:
@@ -38,14 +39,12 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Configure AWS
-      run: |
-        aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws configure set region us-east-1    
-        export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-        export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+        aws-region: us-east-1
+
     - name: Build or pull datastream-deps
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then

--- a/.github/workflows/test_datastream_ngiab.yaml
+++ b/.github/workflows/test_datastream_ngiab.yaml
@@ -42,7 +42,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
         aws-region: us-east-1
 
     - name: Build or pull datastream-deps

--- a/.github/workflows/test_datastream_ngiab.yaml
+++ b/.github/workflows/test_datastream_ngiab.yaml
@@ -8,21 +8,23 @@ on:
     paths:
       - .github/workflow/test_datastream_options.yaml
       - 'docker/**'
-      - '!docker/README.md'      
-      - 'scripts/datastream'  
-      - 'src/datastreamcli/**'  
-      - '!src/datastreamcli/README.md'      
+      - '!docker/README.md'
+      - 'scripts/datastream'
+      - 'src/datastreamcli/**'
+      - '!src/datastreamcli/README.md'
+      - 'versions.yml'
 
   pull_request:
     branches:
-      - main  
+      - main
     paths:
       - .github/workflow/test_datastream_options.yaml
       - 'docker/**'
-      - '!docker/README.md'      
-      - 'scripts/datastream'  
-      - 'src/datastreamcli/**'  
-      - '!src/datastreamcli/README.md'            
+      - '!docker/README.md'
+      - 'scripts/datastream'
+      - 'src/datastreamcli/**'
+      - '!src/datastreamcli/README.md'
+      - 'versions.yml'            
 
 permissions:
   contents: read      
@@ -47,17 +49,30 @@ jobs:
     - name: Build or pull datastream-deps
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          DIFF=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
         elif [ "${{ github.event_name }}" == "push" ]; then
-          DIFF=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+          BASE=${{ github.event.before }}
+          HEAD=${{ github.sha }}
         else
-          DIFF=$(git diff --name-only origin/main...HEAD)
+          BASE=origin/main
+          HEAD=HEAD
         fi
+        DIFF=$(git diff --name-only $BASE...$HEAD)
+        BUILD_DEPS=false
         if echo "$DIFF" | grep -q "docker/Dockerfile.datastream-deps"; then
-          echo "Deps Dockerfile changed, building..."
+          BUILD_DEPS=true
+        fi
+        if echo "$DIFF" | grep -q "versions.yml"; then
+          if git diff -U0 $BASE...$HEAD -- versions.yml | grep -q "datastream-deps"; then
+            BUILD_DEPS=true
+          fi
+        fi
+        if [ "$BUILD_DEPS" = true ]; then
+          echo "Deps changed, building..."
           docker compose -f docker/docker-compose.yml build datastream-deps
         else
-          echo "Deps Dockerfile unchanged, pulling from Docker Hub..."
+          echo "Deps unchanged, pulling from Docker Hub..."
           docker pull awiciroh/datastream-deps:latest
         fi
 

--- a/.github/workflows/test_datastream_options.yaml
+++ b/.github/workflows/test_datastream_options.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Build or pull datastream-deps

--- a/.github/workflows/test_datastream_options.yaml
+++ b/.github/workflows/test_datastream_options.yaml
@@ -18,6 +18,7 @@ on:
       - 'docker/Dockerfile.datastream-deps'
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -28,11 +29,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
 
       - name: Build or pull datastream-deps
         run: |

--- a/.github/workflows/test_datastream_options.yaml
+++ b/.github/workflows/test_datastream_options.yaml
@@ -8,12 +8,14 @@ on:
       - '.github/workflows/test_datastream_options.yaml'
       - 'scripts/datastream'
       - 'versions.yml'
+      - 'docker/Dockerfile.datastream-deps'
   pull_request:
     branches: [main]
     paths:
       - '.github/workflows/test_datastream_options.yaml'
       - 'scripts/datastream'
       - 'versions.yml'
+      - 'docker/Dockerfile.datastream-deps'
 
 permissions:
   contents: read
@@ -35,17 +37,30 @@ jobs:
       - name: Build or pull datastream-deps
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            DIFF=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})
+            BASE=${{ github.event.pull_request.base.sha }}
+            HEAD=${{ github.event.pull_request.head.sha }}
           elif [ "${{ github.event_name }}" == "push" ]; then
-            DIFF=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+            BASE=${{ github.event.before }}
+            HEAD=${{ github.sha }}
           else
-            DIFF=$(git diff --name-only origin/main...HEAD)
+            BASE=origin/main
+            HEAD=HEAD
           fi
+          DIFF=$(git diff --name-only $BASE...$HEAD)
+          BUILD_DEPS=false
           if echo "$DIFF" | grep -q "docker/Dockerfile.datastream-deps"; then
-            echo "Deps Dockerfile changed, building..."
+            BUILD_DEPS=true
+          fi
+          if echo "$DIFF" | grep -q "versions.yml"; then
+            if git diff -U0 $BASE...$HEAD -- versions.yml | grep -q "datastream-deps"; then
+              BUILD_DEPS=true
+            fi
+          fi
+          if [ "$BUILD_DEPS" = true ]; then
+            echo "Deps changed, building..."
             docker compose -f docker/docker-compose.yml build datastream-deps
           else
-            echo "Deps Dockerfile unchanged, pulling from Docker Hub..."
+            echo "Deps unchanged, pulling from Docker Hub..."
             docker pull awiciroh/datastream-deps:latest
           fi
 

--- a/.github/workflows/test_datastream_options.yaml
+++ b/.github/workflows/test_datastream_options.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Build or pull datastream-deps

--- a/.github/workflows/test_datastream_options_forcings_sources.yaml
+++ b/.github/workflows/test_datastream_options_forcings_sources.yaml
@@ -8,12 +8,14 @@ on:
       - '.github/workflows/test_datastream_options_forcings_sources.yaml'
       - 'scripts/datastream'
       - 'versions.yml'
+      - 'docker/Dockerfile.datastream-deps'
   pull_request:
     branches: [main]
     paths:
       - '.github/workflows/test_datastream_options_forcings_sources.yaml'
       - 'scripts/datastream'
       - 'versions.yml'
+      - 'docker/Dockerfile.datastream-deps'
 
 permissions:
   contents: read
@@ -35,17 +37,30 @@ jobs:
       - name: Build or pull datastream-deps
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            DIFF=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})
+            BASE=${{ github.event.pull_request.base.sha }}
+            HEAD=${{ github.event.pull_request.head.sha }}
           elif [ "${{ github.event_name }}" == "push" ]; then
-            DIFF=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+            BASE=${{ github.event.before }}
+            HEAD=${{ github.sha }}
           else
-            DIFF=$(git diff --name-only origin/main...HEAD)
+            BASE=origin/main
+            HEAD=HEAD
           fi
+          DIFF=$(git diff --name-only $BASE...$HEAD)
+          BUILD_DEPS=false
           if echo "$DIFF" | grep -q "docker/Dockerfile.datastream-deps"; then
-            echo "Deps Dockerfile changed, building..."
+            BUILD_DEPS=true
+          fi
+          if echo "$DIFF" | grep -q "versions.yml"; then
+            if git diff -U0 $BASE...$HEAD -- versions.yml | grep -q "datastream-deps"; then
+              BUILD_DEPS=true
+            fi
+          fi
+          if [ "$BUILD_DEPS" = true ]; then
+            echo "Deps changed, building..."
             docker compose -f docker/docker-compose.yml build datastream-deps
           else
-            echo "Deps Dockerfile unchanged, pulling from Docker Hub..."
+            echo "Deps unchanged, pulling from Docker Hub..."
             docker pull awiciroh/datastream-deps:latest
           fi
 

--- a/.github/workflows/test_datastream_options_forcings_sources.yaml
+++ b/.github/workflows/test_datastream_options_forcings_sources.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Build or pull datastream-deps

--- a/.github/workflows/test_datastream_options_forcings_sources.yaml
+++ b/.github/workflows/test_datastream_options_forcings_sources.yaml
@@ -18,6 +18,7 @@ on:
       - 'docker/Dockerfile.datastream-deps'
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -28,11 +29,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
 
       - name: Build or pull datastream-deps
         run: |

--- a/.github/workflows/test_datastream_options_forcings_sources.yaml
+++ b/.github/workflows/test_datastream_options_forcings_sources.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Build or pull datastream-deps

--- a/.github/workflows/test_datastream_python_bmi_conf_generation.yaml
+++ b/.github/workflows/test_datastream_python_bmi_conf_generation.yaml
@@ -33,9 +33,9 @@ jobs:
   test-bmi-config-generation:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
         

--- a/.github/workflows/test_datastream_python_configuration.yaml
+++ b/.github/workflows/test_datastream_python_configuration.yaml
@@ -31,9 +31,9 @@ jobs:
   test-python-configuration:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
         

--- a/.github/workflows/test_datastream_python_model_realizations.yaml
+++ b/.github/workflows/test_datastream_python_model_realizations.yaml
@@ -31,9 +31,9 @@ jobs:
   test-python-validation:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
         

--- a/.github/workflows/test_datastream_python_troute_conversion.yaml
+++ b/.github/workflows/test_datastream_python_troute_conversion.yaml
@@ -31,9 +31,9 @@ jobs:
   test-python-troute-conversion:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
         

--- a/.github/workflows/test_datastream_python_validation.yaml
+++ b/.github/workflows/test_datastream_python_validation.yaml
@@ -31,9 +31,9 @@ jobs:
   test-python-validation:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
         

--- a/.github/workflows/test_teehr_integration.yaml
+++ b/.github/workflows/test_teehr_integration.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
         aws-region: us-east-1
 
     - name: Build or pull datastream-deps

--- a/.github/workflows/test_teehr_integration.yaml
+++ b/.github/workflows/test_teehr_integration.yaml
@@ -19,7 +19,8 @@ on:
       - 'docker/Dockerfile.datastream-deps'      
 
 permissions:
-  contents: read  
+  id-token: write
+  contents: read
 
 jobs:
   test-datastream-options:
@@ -30,15 +31,11 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Configure AWS
-      run: |
-        aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws configure set region us-east-1    
-        export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-        export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        echo $AWS_ACCESS_KEY_ID
-        echo $AWS_SECRET_ACCESS_KEY
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+        aws-region: us-east-1
 
     - name: Build or pull datastream-deps
       run: |

--- a/.github/workflows/test_teehr_integration.yaml
+++ b/.github/workflows/test_teehr_integration.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
         aws-region: us-east-1
 
     - name: Build or pull datastream-deps

--- a/.github/workflows/test_teehr_integration.yaml
+++ b/.github/workflows/test_teehr_integration.yaml
@@ -6,13 +6,17 @@ on:
     branches:
       - main
     paths:
-      - 'scripts/datastream'    
-      
+      - 'scripts/datastream'
+      - 'versions.yml'
+      - 'docker/Dockerfile.datastream-deps'
+
   push:
     branches:
       - main
     paths:
-      - 'scripts/datastream'      
+      - 'scripts/datastream'
+      - 'versions.yml'
+      - 'docker/Dockerfile.datastream-deps'      
 
 permissions:
   contents: read  
@@ -39,17 +43,30 @@ jobs:
     - name: Build or pull datastream-deps
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          DIFF=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
         elif [ "${{ github.event_name }}" == "push" ]; then
-          DIFF=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+          BASE=${{ github.event.before }}
+          HEAD=${{ github.sha }}
         else
-          DIFF=$(git diff --name-only origin/main...HEAD)
+          BASE=origin/main
+          HEAD=HEAD
         fi
+        DIFF=$(git diff --name-only $BASE...$HEAD)
+        BUILD_DEPS=false
         if echo "$DIFF" | grep -q "docker/Dockerfile.datastream-deps"; then
-          echo "Deps Dockerfile changed, building..."
+          BUILD_DEPS=true
+        fi
+        if echo "$DIFF" | grep -q "versions.yml"; then
+          if git diff -U0 $BASE...$HEAD -- versions.yml | grep -q "datastream-deps"; then
+            BUILD_DEPS=true
+          fi
+        fi
+        if [ "$BUILD_DEPS" = true ]; then
+          echo "Deps changed, building..."
           docker compose -f docker/docker-compose.yml build datastream-deps
         else
-          echo "Deps Dockerfile unchanged, pulling from Docker Hub..."
+          echo "Deps unchanged, pulling from Docker Hub..."
           docker pull awiciroh/datastream-deps:latest
         fi
 


### PR DESCRIPTION
## Summary
- Replace static `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` secrets with OIDC via `aws-actions/configure-aws-credentials@v4`
- Add `id-token: write` permission to all AWS-authenticated workflows
- Add `AWS_SESSION_TOKEN` for Docker container credential passthrough
- Role: `github-actions-terraform-oidc`