### PR TITLE
resolve DAILY in troute restart path for cli args flow

### DIFF
--- a/scripts/datastream
+++ b/scripts/datastream
@@ -445,6 +445,10 @@ else
             CROSSWALK_BASE=""
             echo "Using troute restarts requires a crosswalk file"
         else
+            if [[ "$TROUTE_RESTART" == *"DAILY"* ]]; then
+                TROUTE_RESTART="${TROUTE_RESTART//DAILY/$run_date}"
+                echo "Updated TROUTE_RESTART: $TROUTE_RESTART"
+            fi
             echo "Using" "$TROUTE_RESTART"
             RESTART_BASE=$(basename "$TROUTE_RESTART")
             get_file "$TROUTE_RESTART" "$NGENRUN_RESTART"/"$RESTART_BASE"


### PR DESCRIPTION
PR #92 added DAILY resolution at the second TROUTE_RESTART block (line 650), but the first block at line 442 (cli args flow, no RESOURCE_DIR) still passes the unresolved path to ngen_configs_gen.py. This makes the routing-only datastream generate a troute config pointing to channel_restart_DAILY_*.nc.