### PR TITLE
resolve DAILY in troute restart path for cli args flow

### DIFF
--- a/scripts/datastream
+++ b/scripts/datastream
@@ -445,6 +445,10 @@ else
             CROSSWALK_BASE=""
             echo "Using troute restarts requires a crosswalk file"
         else
+            if [[ "$TROUTE_RESTART" == *"DAILY"* ]]; then
+                TROUTE_RESTART="${TROUTE_RESTART//DAILY/$run_date}"
+                echo "Updated TROUTE_RESTART: $TROUTE_RESTART"
+            fi
             echo "Using" "$TROUTE_RESTART"
             RESTART_BASE=$(basename "$TROUTE_RESTART")
             get_file "$TROUTE_RESTART" "$NGENRUN_RESTART"/"$RESTART_BASE"


### PR DESCRIPTION
Validated via end-to-end test today against an actual restart file on S3.

PR #92 added DAILY replacement at line 650, but in the cli args flow TROUTE_RESTART is used at line 442 to set RESTART_BASE via basename, before line 650 runs. By then configure_datastream.py and ngen_configs_gen.py have already written troute.yaml with literal DAILY.

Mirrors the NGEN_FORCINGS pattern from line 428. AMI-side workaround currently in place at ngen-datastream#353.