### PR TITLE
write sloth outputs to dummy folder

### DIFF
--- a/configs/ngen/realization_sloth_troute.json
+++ b/configs/ngen/realization_sloth_troute.json
@@ -46,5 +46,5 @@
         "t_route_config_file_with_path": "./config/troute.yaml"
     },
     "remotes_enabled": false,
-    "output_root": "./outputs/ngen"
+    "output_root": "./outputs/sloth"
 }


### PR DESCRIPTION
When sloth is run in the routing-only datastream, its outputs overwrite the runoff data generated from the NWM's channel routing outputs, causing all of the routing-only outputs to be 0 (closes issue #97). This change pushes the sloth outputs to a dummy folder so that the correct runoff values don't disappear. 

The newly corrected realization probably also needs to get pushed up to S3

Tested locally with commands:
`export DS_TAG=1.7.0 NGIAB_TAG=v1.7.0 SKIP_VALIDATION=True`
`rm -rf quinn_test && ./datastream -s DAILY -n 4 --FORCING_SOURCE NWM_V3_CHRTOUT_SHORT_RANGE_00 -d /Users/qylee/Documents/NRDS/datastreamcli/scripts/quinn_test -g ../configs/nextgen_VPU_09.gpkg -R ../configs/ngen/realization_sloth_troute.json  `