### PR TITLE
Edit meta env vars

### DIFF
--- a/.github/workflows/test_datastream_options.yaml
+++ b/.github/workflows/test_datastream_options.yaml
@@ -187,7 +187,7 @@ jobs:
           cp ./data/datastream_test/datastream-metadata/datastream.env ./data/cache
           cp -r "$RESOURCES_RUN" ./data/cache
           rm -rf "$WS/data/datastream_test"
-          ./scripts/datastream -c ./data/cache/datastream.env
+          ./scripts/datastream -c ./data/cache/datastream.env -d "$WS/data/datastream_test"
 
           # Test 3: No resources (cached)
           echo "=== Test 3: No resources (cached) ==="

--- a/src/datastreamcli/configure_datastream.py
+++ b/src/datastreamcli/configure_datastream.py
@@ -85,31 +85,30 @@ def config_class2dict(args):
 
 def config_class2envs(args, filename='config.env'):
     """
-    Extracts values from args and writes them to a file in a format that can be sourced in a shell script.
+    Write set config values to a file that can be sourced in a shell script.
 
-    Parameters:
-    args: The argparse Namespace object containing the configuration values.
-    filename: The name of the file to write the environment variables to (default: 'config.env').
-    use_export: If True, includes 'export' keyword for variables (default: True).
+    Unset/blank values are skipped, and DATA_DIR is omitted so a reproduction must pass it at the CLI (-d).
+
+    args: argparse Namespace with the configuration values.
+    filename: file to write the environment variables to (default: 'config.env').
     """
     config = config_class2dict(args)  # Reuse the dict function to get structured config
 
-    with open(filename, 'w') as f:
-        # Write globals
-        for key, value in config['globals'].items():
-            env_key = key.upper()
-            if value is not None:
-                f.write(f'{env_key}="{value}"\n')
-            else:
-                f.write(f'{env_key}=\n')
+    skip_globals = {"data_dir"}  # machine-specific, not reproducible
 
-        # Write subset
+    def is_set(value):
+        return value is not None and not (isinstance(value, str) and value.strip() == "")
+
+    with open(filename, 'w') as f:
+        for key, value in config['globals'].items():
+            if key in skip_globals or not is_set(value):
+                continue
+            f.write(f'{key.upper()}="{value}"\n')
+
         for key, value in config['subset'].items():
-            env_key = f'SUBSET_{key.upper()}'
-            if value is not None:
-                f.write(f'{env_key}="{value}"\n')
-            else:
-                f.write(f'{env_key}=\n')
+            if not is_set(value):
+                continue
+            f.write(f'SUBSET_{key.upper()}="{value}"\n')
 
 def write_json(conf, out_dir, name):
     conf_path = Path(out_dir,name)


### PR DESCRIPTION
Closes https://github.com/CIROH-UA/datastreamcli/issues/107 .  Previously, DATA_DIR was written out in the .env file that is for reproducing simulations. The user reproducing the sim will have a different local path, so this variable will always need to be overwritten, or just removed as is accomplished in this PR. Also blank variables are not written.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
