### PR TITLE
skip troute netcdf2parquet if EVAL is on

### DIFF
--- a/scripts/datastream
+++ b/scripts/datastream
@@ -730,7 +730,10 @@ log_time "NGEN_END"
 log_time "CONVERT_TROUTE_NC2PARQUET_START"
 NC2PARQUET_CONVERTER=$DOCKER_PY"nc2parquet.py"
 DOCKER_TROUTE_DIR=$DOCKER_MOUNT/outputs/troute/
-if [ "$DRYRUN" == "True" ]; then
+if [ "$EVAL" == "True" ]; then
+    # TEEHR reads the t-route netcdf outputs, so leave them in place
+    echo "EVAL is True - CONVERT_TROUTE_NC2PARQUET SKIPPED"
+elif [ "$DRYRUN" == "True" ]; then
     echo "DRYRUN - CONVERT_TROUTE_NC2PARQUET SKIPPED"
     echo "COMMAND: docker run --rm -v "$NGEN_RUN":"$DOCKER_MOUNT" \
         -u $(id -u):$(id -g) \
@@ -808,7 +811,7 @@ if [ -n "$S3_BUCKET" ]; then
 #    aws s3 cp $NGENRUN_TAR "s3://$S3_BUCKET/${S3_PREFIX%/}/$TAR_NAME"
     aws s3 cp $DATA_DIR/merkdir.file "s3://$S3_BUCKET/${S3_PREFIX%/}/merkdir.file"
     aws s3 sync $DATASTREAM_META "s3://$S3_BUCKET/${S3_PREFIX%/}/datastream-metadata"
-    if [ ${NTROUTE} -gt 0 ]; then
+    if [ ${NTROUTE:-0} -gt 0 ]; then
         aws s3 sync $TROUTE_TMP "s3://$S3_BUCKET/${S3_PREFIX%/}/ngen-run/outputs/troute/"
         rm -rf $TROUTE_TMP
     fi


### PR DESCRIPTION
This PR fixes https://github.com/CIROH-UA/datastreamcli/issues/52 by avoiding the output file conversion if troute is on. 

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
